### PR TITLE
Updated design: hide advanced settings

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -76,7 +76,7 @@ details > summary {
           </div>
           <div class="form-group" v-if="options.isAdvanced">
             <label for="inp-min-length">Word length</label>
-            <div class="grid grid--1-1">
+            <div class="grid grid-mobile--1-1 grid--1-1">
                 <input
                   type="number"
                   class="form-control"

--- a/src/app.vue
+++ b/src/app.vue
@@ -5,6 +5,11 @@
 .container {
   width: 95%;
 }
+
+details > summary {
+  user-select: none;
+  cursor: pointer;
+}
 </style>
 
 <template>
@@ -17,7 +22,7 @@
           <div class="form-group">
             <label for="sel-dictionary">Dictionary</label>
             <select
-              class="form-control"
+              class="form-control form-group"
               id="sel-dictionary"
               v-model="options.dictionary"
             >
@@ -29,8 +34,25 @@
                 {{ dict.name }}
               </option>
             </select>
+            <DictionaryInfo
+              v-bind:selected="options.dictionary"
+            ></DictionaryInfo>
           </div>
-          <div class="form-group">
+
+          <button
+            type="button"
+            class="btn btn-block form-group"
+            @click.prevent="toggleAdvanced"
+          >
+            <template v-if="options.isAdvanced">
+              Hide advanced options
+            </template>
+            <template v-else>
+              Show advanced options
+            </template>
+          </button>
+
+          <div class="form-group" v-if="options.isAdvanced">
             <label for="inp-words">Words count</label>
             <input
               type="number"
@@ -41,7 +63,7 @@
               max="20"
             />
           </div>
-          <div class="form-group">
+          <div class="form-group" v-if="options.isAdvanced">
             <label for="inp-digits">Digits count</label>
             <input
               type="number"
@@ -52,29 +74,30 @@
               max="20"
             />
           </div>
-          <div class="form-group">
-            <label for="inp-min-length">Minimum word length</label>
-            <input
-              type="number"
-              class="form-control"
-              id="inp-min-length"
-              v-model.number="options.minWordLength"
-              min="1"
-              max="15"
-            />
+          <div class="form-group" v-if="options.isAdvanced">
+            <label for="inp-min-length">Word length</label>
+            <div class="grid grid--1-1">
+                <input
+                  type="number"
+                  class="form-control"
+                  id="inp-min-length"
+                  v-model.number="options.minWordLength"
+                  min="1"
+                  max="15"
+                  placeholder="Min word length"
+                />
+                <input
+                  type="number"
+                  class="form-control"
+                  id="inp-max-length"
+                  v-model.number="options.maxWordLength"
+                  min="1"
+                  max="15"
+                  placeholder="Max word length"
+                />
+            </div>
           </div>
-          <div class="form-group">
-            <label for="inp-max-length">Maximum word length</label>
-            <input
-              type="number"
-              class="form-control"
-              id="inp-max-length"
-              v-model.number="options.maxWordLength"
-              min="1"
-              max="15"
-            />
-          </div>
-          <div class="form-group">
+          <div class="form-group" v-if="options.isAdvanced">
             <label for="sel-case">Word case</label>
             <select
               class="form-control"
@@ -90,7 +113,7 @@
               </option>
             </select>
           </div>
-          <div class="form-group">
+          <div class="form-group" v-if="options.isAdvanced">
             <label for="sel-delimiter">Delimiter</label>
             <select
               class="form-control"
@@ -106,7 +129,7 @@
               </option>
             </select>
           </div>
-          <div class="form-group">
+          <div class="form-group" v-if="options.isAdvanced">
             <label for="inp-phrases-count">Phrases to generate</label>
             <input
               type="number"
@@ -117,6 +140,7 @@
               max="30"
             />
           </div>
+
           <div class="form-group">
             <div class="control">
               <button
@@ -130,10 +154,9 @@
           </div>
         </form>
       </div>
-      <div v-if="result?.length === 0">
+      <div v-if="result?.length === 0 && !error">
         <About></About>
         <SourceCode></SourceCode>
-        <DictionaryInfo v-bind:selected="options.dictionary"></DictionaryInfo>
       </div>
       <PasswordList
         v-else
@@ -147,13 +170,13 @@
 </template>
 
 <script lang="ts">
-import fontPreload from "./components/font-preload.vue";
-import footer from "./components/footer.vue";
-import about from "./components/about.vue";
-import sourceCode from "./components/source-code.vue";
-import dictionaryInfo from "./components/dictionary-info.vue";
-import header from "./components/header.vue";
-import passwordList from "./components/password-list.vue";
+import FontPreload from "./components/font-preload.vue";
+import Footer from "./components/footer.vue";
+import About from "./components/about.vue";
+import SourceCode from "./components/source-code.vue";
+import DictionaryInfo from "./components/dictionary-info.vue";
+import Header from "./components/header.vue";
+import PasswordList from "./components/password-list.vue";
 
 import dictionaryList from "./libs/load-dictionaries";
 import { Options } from "./libs/settings-storage";
@@ -185,15 +208,18 @@ export default defineComponent({
     };
   },
   components: {
-    FontPreload: fontPreload,
-    Footer: footer,
-    About: about,
-    SourceCode: sourceCode,
-    DictionaryInfo: dictionaryInfo,
-    Header: header,
-    PasswordList: passwordList,
+    FontPreload,
+    Footer,
+    About,
+    SourceCode,
+    DictionaryInfo,
+    Header,
+    PasswordList,
   },
   methods: {
+    toggleAdvanced() {
+      this.options.isAdvanced = !this.options.isAdvanced;
+    },
     reset() {
       this.result = [];
       this.error = undefined;

--- a/src/components/about.vue
+++ b/src/components/about.vue
@@ -11,7 +11,7 @@
         Also, you have an option to add a few digits to make it more secure.
       </div>
       <div>
-        <a href="https://xkcd.com/936/" target="_blank" rel="nofollow noopener"
+        <a href="https://xkcd.com/936/" target="_blank" rel="noopener"
           >Check out the xkcd comic about password strength</a
         >.
       </div>

--- a/src/components/dictionary-info.vue
+++ b/src/components/dictionary-info.vue
@@ -6,7 +6,7 @@
         <a
           :href="source"
           target="_blank"
-          rel="nofollow noopener"
+          rel="noopener"
           title="Source"
         >
           <ExternalLinkIcon class="icon"></ExternalLinkIcon>

--- a/src/components/dictionary-info.vue
+++ b/src/components/dictionary-info.vue
@@ -42,7 +42,7 @@
 <script lang="ts">
 import { defineComponent } from "@vue/runtime-core";
 import dictionaryList from "../libs/load-dictionaries";
-import { ExternalLinkIcon } from "@heroicons/vue/outline";
+import { default as ExternalLinkIcon } from "@heroicons/vue/outline/ExternalLinkIcon";
 
 const dictionaries = dictionaryList.list();
 

--- a/src/components/dictionary-info.vue
+++ b/src/components/dictionary-info.vue
@@ -1,17 +1,24 @@
 <template>
   <article class="panel panel-compact">
-    <h2 class="panel-heading">Dictionary information</h2>
+    <h2 class="panel-heading">Dictionary Info</h2>
     <div class="panel-body">
-      <h3>{{ name }}</h3>
-      <p>{{ title }}</p>
-    </div>
-    <div class="panel-footer">
-      <a :href="source" target="_blank" rel="nofollow noopener">Source</a>
+      <div>
+        <a :href="source" target="_blank" rel="nofollow noopener">
+          <ExternalLinkIcon class="icon"></ExternalLinkIcon>
+        </a>
+        {{ title }}
+      </div>
     </div>
   </article>
 </template>
 
 <style lang="scss" scoped>
+.icon {
+  width: 1.25rem;
+  float: right;
+  margin: 0 0 1ch 1ch;
+}
+
 .panel {
   & > .panel-body {
     & > h3 {
@@ -30,6 +37,8 @@
 <script lang="ts">
 import { defineComponent } from "@vue/runtime-core";
 import dictionaryList from "../libs/load-dictionaries";
+import { ExternalLinkIcon } from "@heroicons/vue/outline";
+
 const dictionaries = dictionaryList.list();
 
 export default defineComponent({
@@ -39,6 +48,7 @@ export default defineComponent({
       required: true,
     },
   },
+
   computed: {
     name(): string {
       return dictionaries.get(this.selected)?.name ?? "";
@@ -50,5 +60,9 @@ export default defineComponent({
       return dictionaries.get(this.selected)?.source ?? "";
     },
   },
+
+  components: {
+    ExternalLinkIcon,
+  }
 });
 </script>

--- a/src/components/dictionary-info.vue
+++ b/src/components/dictionary-info.vue
@@ -42,7 +42,7 @@
 <script lang="ts">
 import { defineComponent } from "@vue/runtime-core";
 import dictionaryList from "../libs/load-dictionaries";
-import { default as ExternalLinkIcon } from "@heroicons/vue/outline/ExternalLinkIcon";
+import ExternalLinkIcon from "@heroicons/vue/outline/ExternalLinkIcon.js";
 
 const dictionaries = dictionaryList.list();
 

--- a/src/components/dictionary-info.vue
+++ b/src/components/dictionary-info.vue
@@ -3,7 +3,12 @@
     <h2 class="panel-heading">Dictionary Info</h2>
     <div class="panel-body">
       <div>
-        <a :href="source" target="_blank" rel="nofollow noopener">
+        <a
+          :href="source"
+          target="_blank"
+          rel="nofollow noopener"
+          title="Source"
+        >
           <ExternalLinkIcon class="icon"></ExternalLinkIcon>
         </a>
         {{ title }}
@@ -63,6 +68,6 @@ export default defineComponent({
 
   components: {
     ExternalLinkIcon,
-  }
+  },
 });
 </script>

--- a/src/components/header.vue
+++ b/src/components/header.vue
@@ -1,8 +1,10 @@
 <template>
   <header>
     <h1>
-      <div class="app-icon"></div>
-      Passphrase Generator
+      <a href=".">
+        <div class="app-icon"></div>
+        Passphrase Generator
+      </a>
     </h1>
   </header>
 </template>
@@ -12,8 +14,8 @@ header {
   margin: 2rem auto;
 }
 
-h1 {
-  display: flex;
+h1 > a {
+  display: inline-flex;
   align-items: center;
   margin: 0;
   font-size: 1.75rem;
@@ -23,7 +25,12 @@ h1 {
   width: 48px;
   height: 48px;
   background: url("../assets/images/icon48.png");
-  background-size: 100% 100%;
+  background-size: 100%;
   margin: 0 1rem 0 0;
+}
+
+a, a:focus, a:hover, a:active, a:visited {
+  text-decoration: none;
+  color: inherit;
 }
 </style>

--- a/src/components/password-list.vue
+++ b/src/components/password-list.vue
@@ -12,7 +12,7 @@
       </div>
 
       <div class="panel-footer">
-        <button @click="reset" class="btn btn-small">Reset</button>
+        <button @click="reset" class="btn btn-small">Clear results</button>
       </div>
     </article>
   </div>

--- a/src/libs/load-dictionaries.ts
+++ b/src/libs/load-dictionaries.ts
@@ -31,7 +31,7 @@ collection.add(
     code: "eff-short1",
     name: "EFF Short 1",
     path: "eff_short_wordlist_1.txt",
-    title: "EFF's New Wordlists for Random Passphrases.",
+    title: "EFF's New Wordlists for Random Passphrases (general short word).",
     source:
       "https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases",
   })

--- a/src/libs/settings-storage.ts
+++ b/src/libs/settings-storage.ts
@@ -12,6 +12,7 @@ class Options implements IOptions {
   wordCase: WordCase = WordCase.Lower;
   delimiter: string = "-";
   count: number = 1;
+  isAdvanced: boolean = false;
 
   constructor() {
     const sp = new URLSearchParams(location.search);
@@ -42,6 +43,8 @@ class Options implements IOptions {
         case "count":
           this.count = parseInt(val);
           break;
+        case "isAdvanced":
+          this.isAdvanced = !!parseInt(val);
       }
     });
   }
@@ -57,6 +60,7 @@ class Options implements IOptions {
     sp.set("wordCase", this.wordCase);
     sp.set("delimiter", this.delimiter);
     sp.set("count", this.count.toString());
+    sp.set("isAdvanced", (+this.isAdvanced).toString());
 
     history.replaceState({}, document.title, "?" + sp.toString());
   }

--- a/src/libs/struct/i-options.ts
+++ b/src/libs/struct/i-options.ts
@@ -64,6 +64,14 @@ interface IOptions {
    * @memberof IOptions
    */
   count?: number;
+
+  /**
+   * Show advanced options UI.
+   *
+   * @type {boolean}
+   * @memberof IOptions
+   */
+  isAdvanced?: boolean;
 }
 
 export default IOptions;


### PR DESCRIPTION
* Hide advanced settings.
* Show dictionary info below dictionary selector.
* Replace "Source" button in dictionary info with an icon.
* Show min and max word length on the same row.
* Header logo is now clickable.